### PR TITLE
feat: enhance sampling configuration for ASGI and Sanic adapters

### DIFF
--- a/docs/adapters/fastapi.md
+++ b/docs/adapters/fastapi.md
@@ -39,8 +39,10 @@ Registers the Profilis ASGI middleware with your FastAPI app so every HTTP reque
 
 - **Automatic request/response timing** — Duration and status code are captured from the ASGI lifecycle.
 - **Route detection** — Uses Starlette/FastAPI route info so you see path templates (e.g. `/api/users/{id}`) instead of raw paths when available.
-- **Route exclusions** — Skip paths like the dashboard or health checks via `route_excludes`.
-- **Config** — Optional `ASGIConfig(sampling_rate=1.0, route_excludes=..., always_sample_errors=True)` from `profilis.asgi.middleware`.
+- **Route exclusions** — Skip paths via `route_excludes` (prefix or exact). Use `"re:..."` for regex (e.g. `"re:^/v1/"`).
+- **Per-route overrides** — `route_overrides`: list of `(pattern, rate)`; first match wins. Lets you sample 100% of critical paths while keeping a lower global rate.
+- **Always sample 5xx** — With `always_sample_errors=True` (default), 5xx and exceptions are always recorded.
+- **Config** — Optional `ASGIConfig(sampling_rate=1.0, route_excludes=..., route_overrides=..., always_sample_errors=True, random_seed=..., rng=...)` from `profilis.asgi.middleware`. Use `random_seed` or `rng` for deterministic tests.
 
 ```python
 from profilis.asgi.middleware import ASGIConfig
@@ -49,7 +51,12 @@ from profilis.fastapi.adapter import instrument_fastapi
 instrument_fastapi(
     app,
     emitter,
-    config=ASGIConfig(sampling_rate=1.0, always_sample_errors=True),
+    config=ASGIConfig(
+        sampling_rate=0.1,
+        route_excludes=["/profilis", "/health", "re:^/static/"],
+        route_overrides=[("/api/critical", 1.0)],
+        always_sample_errors=True,
+    ),
     route_excludes=["/profilis", "/health"],
 )
 ```

--- a/docs/adapters/sanic.md
+++ b/docs/adapters/sanic.md
@@ -43,7 +43,7 @@ Attaches Profilis request, response, and exception middleware to your Sanic app 
 
 - **Request/response timing** — Duration and status code are recorded.
 - **Exception handling** — Server errors and unhandled exceptions are recorded with error info.
-- **Config** — `SanicConfig(sampling_rate=1.0, route_excludes=..., always_sample_errors=True)`.
+- **Config** — `SanicConfig(sampling_rate=1.0, route_excludes=..., route_overrides=..., always_sample_errors=True, random_seed=..., rng=...)`. Route excludes support prefix or regex (`"re:..."`). Per-route overrides: `route_overrides=[(pattern, rate), ...]`. Use `random_seed` or `rng` for deterministic tests.
 - **Optional ASGI UI mount** — You can pass `mount_asgi_app` and `mount_path` to mount an ASGI app (e.g. dashboard) if your Sanic version supports it; otherwise use the blueprint below.
 
 ```python
@@ -53,8 +53,9 @@ instrument_sanic_app(
     app,
     emitter,
     SanicConfig(
-        sampling_rate=1.0,
-        route_excludes=["/profilis", "/health"],
+        sampling_rate=0.1,
+        route_excludes=["/profilis", "/health", "re:^/static/"],
+        route_overrides=[("/api/critical", 1.0)],
         always_sample_errors=True,
     ),
 )

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -109,6 +109,31 @@ profilis = ProfilisFlask(
 )
 ```
 
+### ASGI / Sanic sampling (FastAPI, Starlette, Sanic)
+
+When using `ASGIConfig` (FastAPI/Starlette) or `SanicConfig` (Sanic), you get:
+
+- **Global `sampling_rate`** — Float in `[0.0, 1.0]`. `1.0` = capture all requests; `0.0` = capture none (except 5xx when `always_sample_errors=True`). Values outside this range raise `ValueError`.
+- **Route excludes** — Paths to skip entirely (prefix or exact match). Use the `re:` prefix for regex (e.g. `"re:^/v[12]/"` to exclude `/v1/` and `/v2/`).
+- **Per-route overrides** — `route_overrides`: iterable of `(pattern, rate)`. First matching pattern wins. Use prefix or `re:...` for regex. Example: sample 100% of `/api/critical` while keeping 10% elsewhere.
+- **Always sample 5xx** — With `always_sample_errors=True` (default), responses with status ≥ 500 and requests that raise exceptions are always recorded, regardless of `sampling_rate`.
+- **Deterministic tests** — Pass `random_seed=int` for reproducible sampling, or `rng=callable` that returns a float in `[0, 1)`.
+
+```python
+from profilis.asgi.middleware import ASGIConfig
+
+# Production: 10% global sampling, exclude health/dashboard, always record 5xx
+config = ASGIConfig(
+    sampling_rate=0.1,
+    route_excludes=["/health", "/profilis", "re:^/static/"],
+    route_overrides=[("/api/critical", 1.0), ("/api/", 0.05)],
+    always_sample_errors=True,
+)
+
+# Tests: deterministic sampling
+config_test = ASGIConfig(sampling_rate=0.5, always_sample_errors=True, random_seed=42)
+```
+
 ## Exporter Configuration
 
 ### JSONL Exporter

--- a/src/profilis/asgi/middleware.py
+++ b/src/profilis/asgi/middleware.py
@@ -5,7 +5,7 @@ Features:
 - Resolves route path from scope['route'].path_format when available
 - Captures method, path/route, status, latency (ns), exception type when present
 - Uses profilis runtime context to allow trace/span propagation
-- Configurable sampling, route excludes, always-sample-errors
+- Configurable sampling, route excludes (prefix/regex), per-route overrides, always-sample-errors (5xx)
 """
 
 from __future__ import annotations
@@ -14,10 +14,25 @@ import contextlib
 import traceback
 import typing as t
 from dataclasses import dataclass
-from random import random
 
 from profilis.core.emitter import Emitter
 from profilis.runtime import get_current_parent_span_id, now_ns
+from profilis.sampling import (
+    _compile_excludes,
+    _compile_overrides,
+    clamp_sampling_rate,
+    get_effective_rate,
+    make_rng,
+)
+from profilis.sampling import (
+    should_exclude_route as sampling_should_exclude_route,
+)
+from profilis.sampling import (
+    should_record_request as sampling_should_record_request,
+)
+from profilis.sampling import (
+    should_sample_request as sampling_should_sample_request,
+)
 
 if t.TYPE_CHECKING:
     from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -40,34 +55,31 @@ class RequestInfo:
 
 
 class ASGIConfig:
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         sampling_rate: float = 1.0,
         route_excludes: t.Iterable[str] | None = None,
+        route_overrides: t.Iterable[tuple[str, float]] | None = None,
         always_sample_errors: bool = True,
+        random_seed: int | None = None,
+        rng: t.Callable[[], float] | None = None,
     ) -> None:
         """
         sampling_rate: float in [0.0, 1.0] probability of capturing a request.
-                       1.0 captures all; 0.0 captures none (except errors if always_sample_errors).
-        route_excludes: iterable of route prefixes or exact strings to skip (e.g. '/static', '/health').
-        always_sample_errors: if True, requests that raise exceptions or yield status >=500 are always recorded.
+                       1.0 captures all; 0.0 captures none (except 5xx if always_sample_errors).
+        route_excludes: iterable of route prefixes or exact strings to skip; use "re:..." for regex.
+        route_overrides: iterable of (pattern, rate) for per-route sampling; first match wins; "re:..." for regex.
+        always_sample_errors: if True, 5xx and exceptions are always recorded.
+        random_seed: optional seed for deterministic sampling (tests).
+        rng: optional callable () -> float in [0,1) for deterministic tests; overrides random_seed if set.
         """
-        self.sampling_rate = float(sampling_rate)
+        self.sampling_rate = clamp_sampling_rate(sampling_rate)
         self.route_excludes = list(route_excludes or [])
+        self.route_overrides = list(route_overrides or [])
         self.always_sample_errors = bool(always_sample_errors)
-
-
-def _should_exclude_route(route: str, excludes: t.Iterable[str]) -> bool:
-    if not excludes:
-        return False
-    for pat in excludes:
-        if not pat:
-            continue
-        # prefix match first for convenience; also allow exact match
-        if route.startswith(pat) or route == pat:
-            return True
-    return False
+        self.random_seed = random_seed
+        self.rng = rng
 
 
 class ProfilisASGIMiddleware:
@@ -84,6 +96,9 @@ class ProfilisASGIMiddleware:
         self.app = app
         self.emitter = emitter
         self.cfg = config or ASGIConfig()
+        self._excludes_compiled = _compile_excludes(self.cfg.route_excludes)
+        self._overrides_compiled = _compile_overrides(self.cfg.route_overrides)
+        self._rng = make_rng(random_seed=self.cfg.random_seed, rng=self.cfg.rng)
 
     def _extract_request_info(self, scope: Scope) -> tuple[str, str | None, str]:
         """Extract method, route, and path from ASGI scope."""
@@ -98,22 +113,21 @@ class ProfilisASGIMiddleware:
         path: str = str(route or scope.get("path", "/"))
         return method, route, path
 
-    def _should_sample_request(self) -> bool:
-        """Determine if this request should be sampled."""
-        return (
-            (random() <= self.cfg.sampling_rate)
-            if (0.0 < self.cfg.sampling_rate < 1.0)
-            else (self.cfg.sampling_rate >= 1.0)
-        )
+    def _should_sample_request(self, path: str) -> bool:
+        """Determine if this request should be sampled (uses per-route rate when overrides match)."""
+        rate = get_effective_rate(path, self._overrides_compiled, self.cfg.sampling_rate)
+        return sampling_should_sample_request(rate, self._rng)
 
     def _should_record_request(
         self, sampled: bool, status_code: int | None, error_info: dict[str, str] | None
     ) -> bool:
-        """Determine if this request should be recorded."""
-        sc = int(status_code or 0)
-        is_error_status = sc >= HTTP_ERROR_STATUS_THRESHOLD
-        return sampled or (
-            self.cfg.always_sample_errors and (error_info is not None or is_error_status)
+        """Determine if this request should be recorded (sampled or 5xx when always_sample_errors)."""
+        return sampling_should_record_request(
+            sampled,
+            status_code,
+            error_info,
+            self.cfg.always_sample_errors,
+            HTTP_ERROR_STATUS_THRESHOLD,
         )
 
     def _create_payload(
@@ -177,13 +191,13 @@ class ProfilisASGIMiddleware:
         # Extract request information
         method, route, path = self._extract_request_info(scope)
 
-        # Check if route should be excluded
-        if _should_exclude_route(path, self.cfg.route_excludes):
+        # Check if route should be excluded (prefix or regex)
+        if sampling_should_exclude_route(path, self._excludes_compiled):
             await self.app(scope, receive, send)
             return
 
-        # Determine sampling
-        sampled = self._should_sample_request()
+        # Determine sampling (global or per-route override)
+        sampled = self._should_sample_request(path)
 
         # Create send wrapper to capture status
         status_code: int | None = None

--- a/src/profilis/sampling.py
+++ b/src/profilis/sampling.py
@@ -1,0 +1,129 @@
+"""Shared sampling policy: global rate, route excludes (prefix/regex), per-route overrides, always 5xx.
+
+Used by ASGI middleware and Sanic adapter for deterministic tests (seedable RNG)
+and consistent behavior across adapters.
+"""
+
+from __future__ import annotations
+
+import re
+import typing as t
+from random import Random, random
+from typing import cast
+
+# Prefix for regex patterns in route_excludes and route_overrides
+REGEX_PREFIX = "re:"
+HTTP_ERROR_STATUS_THRESHOLD = 500
+
+
+def _compile_excludes(excludes: t.Iterable[str]) -> list[tuple[str, t.Union[str, re.Pattern[str]]]]:
+    """Compile route_excludes into (type, pattern) list. type is 'prefix' or 'regex'."""
+    result: list[tuple[str, t.Union[str, re.Pattern[str]]]] = []
+    for pat in excludes or []:
+        if not pat:
+            continue
+        if pat.startswith(REGEX_PREFIX):
+            try:
+                result.append(("regex", re.compile(pat[len(REGEX_PREFIX) :])))
+            except re.error:
+                # invalid regex: treat as literal prefix
+                result.append(("prefix", pat))
+        else:
+            result.append(("prefix", pat))
+    return result
+
+
+def should_exclude_route(
+    path: str, compiled: list[tuple[str, t.Union[str, re.Pattern[str]]]]
+) -> bool:
+    """Return True if path matches any exclude (prefix or regex)."""
+    for kind, pattern in compiled:
+        if kind == "prefix":
+            assert isinstance(pattern, str)
+            if path.startswith(pattern) or path == pattern:
+                return True
+        elif kind == "regex":
+            if cast(re.Pattern[str], pattern).search(path):
+                return True
+    return False
+
+
+def _compile_overrides(
+    overrides: t.Iterable[tuple[str, float]] | None,
+) -> list[tuple[str, t.Union[str, re.Pattern[str]], float]]:
+    """Compile route_overrides into (type, pattern, rate) list."""
+    result: list[tuple[str, t.Union[str, re.Pattern[str]], float]] = []
+    for pat, rate in overrides or []:
+        if not pat:
+            continue
+        r = float(rate)
+        if not 0.0 <= r <= 1.0:
+            continue
+        if pat.startswith(REGEX_PREFIX):
+            try:
+                result.append(("regex", re.compile(pat[len(REGEX_PREFIX) :]), r))
+            except re.error:
+                result.append(("prefix", pat, r))
+        else:
+            result.append(("prefix", pat, r))
+    return result
+
+
+def get_effective_rate(
+    path: str,
+    compiled_overrides: list[tuple[str, t.Union[str, re.Pattern[str]], float]],
+    default_rate: float,
+) -> float:
+    """Return sampling rate for path: first matching override, or default_rate."""
+    for kind, pattern, rate in compiled_overrides:
+        if kind == "prefix":
+            assert isinstance(pattern, str)
+            if path.startswith(pattern) or path == pattern:
+                return rate
+        elif kind == "regex":
+            if cast(re.Pattern[str], pattern).search(path):
+                return rate
+    return default_rate
+
+
+def should_sample_request(rate: float, rng: t.Callable[[], float]) -> bool:
+    """Return True if this request should be sampled according to rate and RNG."""
+    if rate >= 1.0:
+        return True
+    if rate <= 0.0:
+        return False
+    return rng() <= rate
+
+
+def should_record_request(
+    sampled: bool,
+    status_code: int | None,
+    error_info: dict[str, str] | None,
+    always_sample_errors: bool,
+    error_threshold: int = HTTP_ERROR_STATUS_THRESHOLD,
+) -> bool:
+    """Return True if request should be recorded (sampled or 5xx/exception when always_sample_errors)."""
+    sc = int(status_code or 0)
+    is_error_status = sc >= error_threshold
+    return sampled or (always_sample_errors and (error_info is not None or is_error_status))
+
+
+def make_rng(
+    random_seed: int | None = None,
+    rng: t.Callable[[], float] | None = None,
+) -> t.Callable[[], float]:
+    """Return a callable that returns a float in [0, 1). Prefer rng if provided, else seeded Random, else system random."""
+    if rng is not None:
+        return rng
+    if random_seed is not None:
+        _rng = Random(random_seed)
+        return _rng.random
+    return random
+
+
+def clamp_sampling_rate(rate: float) -> float:
+    """Clamp sampling rate to [0.0, 1.0]. Raises ValueError if not in range (for strict validation)."""
+    r = float(rate)
+    if not 0.0 <= r <= 1.0:
+        raise ValueError(f"sampling_rate must be in [0.0, 1.0], got {rate}")
+    return r

--- a/src/profilis/sanic/adapter.py
+++ b/src/profilis/sanic/adapter.py
@@ -18,6 +18,22 @@ from sanic import Sanic
 from profilis.core.emitter import Emitter
 from profilis.runtime import now_ns
 from profilis.runtime.context import get_current_parent_span_id
+from profilis.sampling import (
+    _compile_excludes,
+    _compile_overrides,
+    clamp_sampling_rate,
+    get_effective_rate,
+    make_rng,
+)
+from profilis.sampling import (
+    should_exclude_route as sampling_should_exclude_route,
+)
+from profilis.sampling import (
+    should_record_request as sampling_should_record_request,
+)
+from profilis.sampling import (
+    should_sample_request as sampling_should_sample_request,
+)
 
 log = logging.getLogger("profilis.sanic")
 
@@ -26,27 +42,22 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 
 
 class SanicConfig:
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         sampling_rate: float = 1.0,
         route_excludes: t.Iterable[str] | None = None,
+        route_overrides: t.Iterable[tuple[str, float]] | None = None,
         always_sample_errors: bool = True,
+        random_seed: int | None = None,
+        rng: t.Callable[[], float] | None = None,
     ) -> None:
-        self.sampling_rate = float(sampling_rate)
+        self.sampling_rate = clamp_sampling_rate(sampling_rate)
         self.route_excludes = list(route_excludes or [])
+        self.route_overrides = list(route_overrides or [])
         self.always_sample_errors = bool(always_sample_errors)
-
-
-def _should_exclude_route(path: str, excludes: t.Iterable[str]) -> bool:
-    if not excludes:
-        return False
-    for pat in excludes:
-        if not pat:
-            continue
-        if path.startswith(pat) or path == pat:
-            return True
-    return False
+        self.random_seed = random_seed
+        self.rng = rng
 
 
 def instrument_sanic_app(  # noqa: PLR0915
@@ -70,18 +81,23 @@ def instrument_sanic_app(  # noqa: PLR0915
     """
 
     cfg = config or SanicConfig()
+    excludes_compiled = _compile_excludes(cfg.route_excludes)
+    overrides_compiled = _compile_overrides(cfg.route_overrides)
+    rng = make_rng(random_seed=cfg.random_seed, rng=cfg.rng)
 
-    # request middleware: set start timestamp and record method/path
+    # request middleware: set start timestamp, sampling decision, method/path
     @app.middleware("request")  # type: ignore[untyped-decorator]
     async def _profilis_request_middleware(request: t.Any) -> None:
         # Only HTTP requests; Sanic uses Request objects for http
         try:
             method = getattr(request, "method", "UNKNOWN")
             path = getattr(request, "path", "/")
-            if _should_exclude_route(path, cfg.route_excludes):
+            if sampling_should_exclude_route(path, excludes_compiled):
                 # mark excluded to short-circuit in response middleware
                 request.ctx._profilis_excluded = True
                 return
+            rate = get_effective_rate(path, overrides_compiled, cfg.sampling_rate)
+            request.ctx._profilis_sampled = sampling_should_sample_request(rate, rng)
             request.ctx._profilis_start_ns = now_ns()
             request.ctx._profilis_method = method
             request.ctx._profilis_path = path
@@ -108,14 +124,9 @@ def instrument_sanic_app(  # noqa: PLR0915
             method = getattr(request.ctx, "_profilis_method", getattr(request, "method", "UNKNOWN"))
             path = getattr(request.ctx, "_profilis_path", getattr(request, "path", "/"))
             route = getattr(request.ctx, "_profilis_route", None)
-            is_error_status = status >= HTTP_INTERNAL_SERVER_ERROR
-            should_record = (
-                (cfg.sampling_rate >= 1.0)
-                or (
-                    0.0 < cfg.sampling_rate < 1.0
-                    and __import__("random").random() <= cfg.sampling_rate
-                )
-                or (cfg.always_sample_errors and is_error_status)
+            sampled = getattr(request.ctx, "_profilis_sampled", False)
+            should_record = sampling_should_record_request(
+                sampled, status, None, cfg.always_sample_errors, HTTP_INTERNAL_SERVER_ERROR
             )
 
             if should_record:

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -37,11 +37,16 @@ def exc_view(request: Any) -> None:
     raise RuntimeError("boom from view")
 
 
+def server_error_view(request: Any) -> JSONResponse:
+    return JSONResponse({"error": "server error"}, status_code=500)
+
+
 def create_app(emitter: Emitter, cfg: Union[ASGIConfig, None] = None) -> ProfilisASGIMiddleware:
     routes = [
         Route("/ok", ok_view),
         Route("/bad", bad_view),
         Route("/exc", exc_view),
+        Route("/server-error", server_error_view),
     ]
     starlette_app = Starlette(routes=routes)
     # wrap as ASGI app manually
@@ -108,4 +113,80 @@ def test_asgi_middleware_respects_route_excludes() -> None:
     # only /bad should be recorded
     assert all((i.get("path") != "/ok") for i in http_items)
     assert any((i.get("path") == "/bad") for i in http_items)
+    col.close()
+
+
+def test_asgi_middleware_rate_zero_2xx_not_recorded() -> None:
+    """With sampling_rate=0, successful (2xx) requests are not recorded."""
+    col, items = make_collector_sink()
+    em = Emitter(col)
+    app = create_app(em, ASGIConfig(sampling_rate=0.0, always_sample_errors=True, random_seed=42))
+    client = TestClient(app)
+
+    client.get("/ok")
+    time.sleep(0.05)
+    http_items = [i for i in items if isinstance(i, dict) and i.get("kind") == "HTTP"]
+    assert not any(i.get("path") == "/ok" and i.get("status") == HTTP_OK for i in http_items)
+    col.close()
+
+
+def test_asgi_middleware_rate_zero_5xx_always_recorded() -> None:
+    """With sampling_rate=0, 5xx responses are always recorded when always_sample_errors=True."""
+    col, items = make_collector_sink()
+    em = Emitter(col)
+    app = create_app(em, ASGIConfig(sampling_rate=0.0, always_sample_errors=True))
+    client = TestClient(app)
+
+    r = client.get("/server-error")
+    assert r.status_code == HTTP_INTERNAL_SERVER_ERROR
+    time.sleep(0.05)
+    http_items = [i for i in items if isinstance(i, dict) and i.get("kind") == "HTTP"]
+    assert any(
+        i.get("path") == "/server-error" and i.get("status") == HTTP_INTERNAL_SERVER_ERROR
+        for i in http_items
+    )
+    col.close()
+
+
+def test_asgi_middleware_route_excludes_regex() -> None:
+    """Route excludes support regex via 're:' prefix."""
+    col, items = make_collector_sink()
+    em = Emitter(col)
+    cfg = ASGIConfig(sampling_rate=1.0, route_excludes=["re:^/ok"])
+    app = create_app(em, cfg)
+    client = TestClient(app)
+
+    client.get("/ok")
+    client.get("/bad")
+    time.sleep(0.05)
+    http_items = [i for i in items if isinstance(i, dict) and i.get("kind") == "HTTP"]
+    assert all(i.get("path") != "/ok" for i in http_items)
+    assert any(i.get("path") == "/bad" for i in http_items)
+    col.close()
+
+
+def test_asgi_middleware_route_override_records_when_override_is_one() -> None:
+    """Per-route override with rate 1.0 records that route even when global rate is 0."""
+    col, items = make_collector_sink()
+    em = Emitter(col)
+    cfg = ASGIConfig(
+        sampling_rate=0.0,
+        always_sample_errors=True,
+        route_overrides=[("/critical", 1.0)],
+        random_seed=42,
+    )
+    routes = [
+        Route("/ok", ok_view),
+        Route("/critical", ok_view),
+    ]
+    starlette_app = Starlette(routes=routes)
+    app = ProfilisASGIMiddleware(starlette_app, em, cfg)
+    client = TestClient(app)
+
+    client.get("/ok")  # global 0 -> not recorded
+    client.get("/critical")  # override 1.0 -> recorded
+    time.sleep(0.05)
+    http_items = [i for i in items if isinstance(i, dict) and i.get("kind") == "HTTP"]
+    assert not any(i.get("path") == "/ok" for i in http_items)
+    assert any(i.get("path") == "/critical" for i in http_items)
     col.close()

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,180 @@
+"""Unit tests for sampling policy: RNG, excludes, overrides, always 5xx."""
+
+from random import Random
+
+import pytest
+
+from profilis.sampling import (
+    _compile_excludes,
+    _compile_overrides,
+    clamp_sampling_rate,
+    get_effective_rate,
+    make_rng,
+    should_exclude_route,
+    should_record_request,
+    should_sample_request,
+)
+
+# --- Deterministic RNG ---
+
+
+def test_make_rng_with_seed_is_deterministic() -> None:
+    rng1 = make_rng(random_seed=42)
+    rng2 = make_rng(random_seed=42)
+    n = 20
+    out1 = [rng1() for _ in range(n)]
+    out2 = [rng2() for _ in range(n)]
+    assert out1 == out2
+
+
+def test_make_rng_seed_matches_stdlib_random() -> None:
+    """Seeded RNG must match Python's Random(seed).random() sequence."""
+    seed = 12345
+    rng = make_rng(random_seed=seed)
+    stdlib = Random(seed)
+    expected = [stdlib.random() for _ in range(10)]
+    actual = [rng() for _ in range(10)]
+    assert actual == expected
+
+
+def test_make_rng_callable_overrides_seed() -> None:
+    """When rng callable is provided, it is used instead of seed."""
+    deterministic = iter([0.0, 0.4, 0.6, 1.0]).__next__
+    rng = make_rng(random_seed=999, rng=deterministic)
+    assert rng() == 0.0
+    assert rng() == 0.4  # noqa: PLR2004
+    assert rng() == 0.6  # noqa: PLR2004
+    assert rng() == 1.0
+
+
+def test_make_rng_default_returns_float_in_unit_interval() -> None:
+    """Default RNG (no seed/callable) returns values in [0, 1)."""
+    rng = make_rng()
+    for _ in range(50):
+        x = rng()
+        assert 0.0 <= x < 1.0
+
+
+# --- clamp_sampling_rate ---
+
+
+def test_clamp_sampling_rate_valid() -> None:
+    assert clamp_sampling_rate(0.0) == 0.0
+    assert clamp_sampling_rate(0.5) == 0.5  # noqa: PLR2004
+    assert clamp_sampling_rate(1.0) == 1.0
+
+
+def test_clamp_sampling_rate_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="sampling_rate must be in"):
+        clamp_sampling_rate(-0.1)
+    with pytest.raises(ValueError, match="sampling_rate must be in"):
+        clamp_sampling_rate(1.5)
+
+
+# --- Route excludes (prefix + regex) ---
+
+
+def test_should_exclude_route_prefix() -> None:
+    compiled = _compile_excludes(["/health", "/static"])
+    assert should_exclude_route("/health", compiled) is True
+    assert should_exclude_route("/healthz", compiled) is True
+    assert should_exclude_route("/static/img/x.png", compiled) is True
+    assert should_exclude_route("/api/foo", compiled) is False
+
+
+def test_should_exclude_route_regex() -> None:
+    compiled = _compile_excludes(["re:^/v[12]/"])
+    assert should_exclude_route("/v1/foo", compiled) is True
+    assert should_exclude_route("/v2/bar", compiled) is True
+    assert should_exclude_route("/v3/bar", compiled) is False
+    assert should_exclude_route("/api/v1/x", compiled) is False
+
+
+def test_should_exclude_route_mixed_prefix_and_regex() -> None:
+    compiled = _compile_excludes(["/health", "re:^/internal/"])
+    assert should_exclude_route("/health", compiled) is True
+    assert should_exclude_route("/internal/debug", compiled) is True
+    assert should_exclude_route("/api/health", compiled) is False
+
+
+def test_should_exclude_route_empty_compiled() -> None:
+    assert should_exclude_route("/any", []) is False
+
+
+# --- Per-route overrides ---
+
+
+def test_get_effective_rate_no_overrides() -> None:
+    assert get_effective_rate("/api/foo", [], 0.1) == 0.1  # noqa: PLR2004
+    assert get_effective_rate("/", [], 1.0) == 1.0
+
+
+def test_get_effective_rate_prefix_override() -> None:
+    compiled = _compile_overrides([("/api/critical", 1.0), ("/api/", 0.2)])
+    assert get_effective_rate("/api/critical", compiled, 0.05) == 1.0
+    assert get_effective_rate("/api/items", compiled, 0.05) == 0.2  # noqa: PLR2004
+    assert get_effective_rate("/other", compiled, 0.05) == 0.05  # noqa: PLR2004
+
+
+def test_get_effective_rate_regex_override() -> None:
+    compiled = _compile_overrides([("re:^/v[12]/", 1.0)])
+    assert get_effective_rate("/v1/foo", compiled, 0.1) == 1.0
+    assert get_effective_rate("/v2/bar", compiled, 0.1) == 1.0
+    assert get_effective_rate("/v3/bar", compiled, 0.1) == 0.1  # noqa: PLR2004
+
+
+# --- should_sample_request ---
+
+
+def test_should_sample_request_rate_one_always_true() -> None:
+    def never_used() -> float:
+        raise AssertionError("should not be called")
+
+    assert should_sample_request(1.0, never_used) is True
+
+
+def test_should_sample_request_rate_zero_always_false() -> None:
+    def never_used() -> float:
+        raise AssertionError("should not be called")
+
+    assert should_sample_request(0.0, never_used) is False
+
+
+def test_should_sample_request_fractional_uses_rng() -> None:
+    # rng <= rate -> sample
+    assert should_sample_request(0.5, lambda: 0.0) is True
+    assert should_sample_request(0.5, lambda: 0.5) is True
+    assert should_sample_request(0.5, lambda: 0.49) is True
+    # rng > rate -> no sample
+    assert should_sample_request(0.5, lambda: 0.51) is False
+    assert should_sample_request(0.5, lambda: 1.0) is False
+
+
+# --- should_record_request (5xx always when always_sample_errors) ---
+
+
+def test_should_record_request_sampled_always_recorded() -> None:
+    assert should_record_request(True, 200, None, False) is True
+    assert should_record_request(True, 500, None, False) is True
+
+
+def test_should_record_request_5xx_always_when_always_sample_errors() -> None:
+    assert should_record_request(False, 500, None, True) is True
+    assert should_record_request(False, 503, None, True) is True
+    assert should_record_request(False, 599, None, True) is True
+
+
+def test_should_record_request_exception_always_when_always_sample_errors() -> None:
+    assert should_record_request(False, 200, {"type": "ValueError"}, True) is True
+    assert should_record_request(False, None, {"type": "RuntimeError"}, True) is True
+
+
+def test_should_record_request_2xx_not_sampled_not_recorded() -> None:
+    assert should_record_request(False, 200, None, True) is False
+    assert should_record_request(False, 201, None, True) is False
+
+
+def test_should_record_request_4xx_not_always_sampled_unless_sampled() -> None:
+    # 4xx is not >= 500, so only recorded if sampled
+    assert should_record_request(True, 404, None, True) is True
+    assert should_record_request(False, 404, None, True) is False


### PR DESCRIPTION
### Summary

Implements configurable sampling for ASGI and Sanic: global `sampling_rate`, route excludes (prefix + regex), per-route overrides, always sampling 5xx/errors, and a seedable RNG for deterministic tests.

### Changes

**New module: `src/profilis/sampling.py`**

- **Global rate**: `sampling_rate` in `[0.0, 1.0]` with validation via `clamp_sampling_rate()` (raises `ValueError` if out of range).
- **Route excludes**: Prefix/exact match and regex via `"re:..."` (e.g. `"re:^/v[12]/"`). Compiled once and shared.
- **Per-route overrides**: `route_overrides` as `(pattern, rate)`; first match wins. Pattern can be prefix or `"re:..."`. `get_effective_rate(path, overrides, default)` returns the rate for a path.
- **Always 5xx**: `should_record_request(sampled, status_code, error_info, always_sample_errors)` so 5xx and exceptions are always recorded when `always_sample_errors=True`.
- **Seedable RNG**: `make_rng(random_seed=..., rng=...)` – use `random_seed` for reproducibility or inject a callable for tests.

**ASGI middleware (`src/profilis/asgi/middleware.py`)**

- `ASGIConfig` extended with `route_overrides`, `random_seed`, and `rng`. `sampling_rate` is validated on init.
- Middleware uses the shared sampling module: compiled excludes/overrides and a single RNG per instance. Sampling decision uses the effective rate for the request path.

**Sanic adapter (`src/profilis/sanic/adapter.py`)**

- `SanicConfig` extended with `route_overrides`, `random_seed`, and `rng`. Same validation and semantics as ASGI.
- Request middleware decides sampling once per request and stores `request.ctx._profilis_sampled`; response/exception middleware use that plus `should_record_request` so behavior matches ASGI and 5xx are always recorded when `always_sample_errors=True`.

**Tests**

- **`tests/test_sampling.py`** (new): Deterministic RNG, `clamp_sampling_rate`, excludes (prefix + regex), overrides, `should_sample_request`, `should_record_request` (5xx/exception always recorded when enabled).
- **`tests/test_asgi_middleware.py`**: Rate 0 + 2xx not recorded; rate 0 + 5xx always recorded; regex exclude `"re:^/ok"`; per-route override so `/critical` is always sampled when global rate is 0.

**Docs**

- **`docs/guides/configuration.md`**: New “ASGI / Sanic sampling” section (global rate, route excludes with regex, per-route overrides, always 5xx, deterministic testing).
- **`docs/adapters/fastapi.md`** and **`docs/adapters/sanic.md`**: Config options and examples updated for `route_overrides`, regex excludes, and `random_seed`/`rng`.

Closes #16.