### PR TITLE
feat: add prometheus exporter and examples for ASGI and Flask

### DIFF
--- a/examples/example_prometheus.py
+++ b/examples/example_prometheus.py
@@ -1,0 +1,82 @@
+"""
+Flask example with Prometheus exporter: /metrics and composite sink.
+
+Run (requires profilis[prometheus,flask]):
+    pip install -e ".[prometheus,flask]"
+    FLASK_APP=examples.example_prometheus flask run
+
+Visit:
+    http://127.0.0.1:5000/ok
+    http://127.0.0.1:5000/slow
+    http://127.0.0.1:5000/metrics   (Prometheus scrape endpoint)
+
+For ASGI (e.g. Starlette/FastAPI), mount the metrics app:
+    from profilis.exporters.prometheus import make_asgi_app
+    app.mount("/metrics", make_asgi_app(registry))
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from flask import Flask
+
+from profilis.core.async_collector import AsyncCollector
+from profilis.core.emitter import Emitter
+from profilis.exporters.console import ConsoleExporter
+from profilis.exporters.prometheus import (
+    PrometheusExporter,
+    make_metrics_blueprint,
+)
+from profilis.flask.adapter import ProfilisFlask
+
+# ------------------- Prometheus registry + composite sink -------------------
+try:
+    from prometheus_client import CollectorRegistry
+except ImportError:
+    raise SystemExit("Install Prometheus support: pip install profilis[prometheus,flask]") from None
+
+registry = CollectorRegistry()
+console = ConsoleExporter(pretty=False)
+prom = PrometheusExporter(
+    registry,
+    service="example-app",
+    instance="localhost:5000",
+    worker="",
+)
+
+
+def sink(batch: list[dict[str, Any]]) -> None:
+    console(batch)
+    prom(batch)
+
+
+collector = AsyncCollector(sink, queue_size=256, flush_interval=0.2, batch_max=64)
+emitter = Emitter(collector)
+
+# ------------------- Flask app -------------------
+app = Flask(__name__)
+ProfilisFlask(
+    app,
+    collector=collector,
+    exclude_routes=["/metrics"],
+    sample=1.0,
+)
+app.register_blueprint(make_metrics_blueprint(registry))
+
+
+# ------------------- Routes -------------------
+@app.get("/ok")
+def ok() -> str:
+    return "ok"
+
+
+@app.get("/slow")
+def slow() -> str:
+    time.sleep(0.05)
+    return "slow"
+
+
+if __name__ == "__main__":
+    app.run(port=5000, debug=True)

--- a/examples/example_prometheus_asgi.py
+++ b/examples/example_prometheus_asgi.py
@@ -1,0 +1,88 @@
+"""
+ASGI (FastAPI) example with Prometheus exporter: /metrics and composite sink.
+
+Run (requires profilis[prometheus,fastapi]):
+    pip install -e ".[prometheus,fastapi]"
+    uvicorn examples.example_prometheus_asgi:app --reload
+
+Visit:
+    http://127.0.0.1:8000/ok
+    http://127.0.0.1:8000/slow
+    http://127.0.0.1:8000/metrics   (Prometheus scrape endpoint)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any
+
+from fastapi import FastAPI
+
+from profilis.asgi.middleware import ASGIConfig
+from profilis.core.async_collector import AsyncCollector
+from profilis.core.emitter import Emitter
+from profilis.exporters.console import ConsoleExporter
+from profilis.exporters.prometheus import PrometheusExporter, make_asgi_app
+from profilis.fastapi.adapter import instrument_fastapi
+
+# ------------------- Prometheus registry + composite sink -------------------
+try:
+    from prometheus_client import CollectorRegistry
+except ImportError:
+    raise SystemExit(
+        "Install Prometheus support: pip install profilis[prometheus,fastapi]"
+    ) from None
+
+registry = CollectorRegistry()
+console = ConsoleExporter(pretty=False)
+prom = PrometheusExporter(
+    registry,
+    service="example-asgi",
+    instance="localhost:8000",
+    worker="",
+)
+
+
+def sink(batch: list[dict[str, Any]]) -> None:
+    console(batch)
+    prom(batch)
+
+
+collector = AsyncCollector(sink, queue_size=256, flush_interval=0.2, batch_max=64)
+emitter = Emitter(collector)
+
+# ------------------- FastAPI app -------------------
+app = FastAPI(title="Profilis ASGI + Prometheus")
+
+instrument_fastapi(
+    app,
+    emitter=emitter,
+    config=ASGIConfig(sampling_rate=1.0, always_sample_errors=True),
+    route_excludes=["/metrics"],
+)
+app.mount("/metrics", make_asgi_app(registry))
+
+
+# ------------------- Routes -------------------
+@app.get("/ok")
+async def ok() -> dict[str, str]:
+    await asyncio.sleep(0.02)
+    return {"status": "ok"}
+
+
+@app.get("/slow")
+async def slow() -> dict[str, str]:
+    await asyncio.sleep(random.uniform(0.05, 0.15))
+    return {"status": "slow"}
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    collector.close()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ sqlalchemy = ["sqlalchemy>=2.0", "aiosqlite", "greenlet"]
 pyodbc = ["pyodbc"]
 mongo = ["pymongo>=4.3", "motor>=3.3"]
 neo4j = ["neo4j>=5.14"]
+prometheus = ["prometheus_client>=0.19"]
 perf = ["orjson>=3.8"]
 all = [
   "flask[async]>=3.0",
@@ -47,6 +48,7 @@ all = [
   "pyodbc",
   "pymongo>=4.3","motor>=3.3",
   "neo4j>=5.14",
+  "prometheus_client>=0.19",
   "orjson>=3.8"
 ]
 dev = [
@@ -57,12 +59,16 @@ dev = [
   "ruff>=0.1.0",
   "black>=23.0",
   "pre-commit>=3.0",
-  "uvicorn>=0.20.0"
+  "uvicorn>=0.20.0",
+  "prometheus_client>=0.19"
 ]
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/src/profilis/core/emitter.py
+++ b/src/profilis/core/emitter.py
@@ -37,7 +37,16 @@ class Emitter:
         ev.update(fn=name, dur_ns=dur_ns, error=error)
         self._collector.enqueue(ev)
 
-    def emit_db(self, query: str, dur_ns: int, rows: int) -> None:
+    def emit_db(
+        self,
+        query: str,
+        dur_ns: int,
+        rows: int,
+        *,
+        db_vendor: str | None = None,
+    ) -> None:
         ev = self._base("DB")
         ev.update(query=query, dur_ns=dur_ns, rows=rows)
+        if db_vendor is not None:
+            ev["db_vendor"] = db_vendor
         self._collector.enqueue(ev)

--- a/src/profilis/exporters/prometheus.py
+++ b/src/profilis/exporters/prometheus.py
@@ -1,0 +1,225 @@
+"""Prometheus exporter: counters and histograms for HTTP, functions, and DB.
+
+Metrics:
+- HTTP: profilis_http_requests_total, profilis_http_request_duration_seconds
+- Functions: profilis_function_calls_total, profilis_function_duration_seconds
+- DB: profilis_db_queries_total, profilis_db_query_duration_seconds
+
+Labels: service, instance, worker, route, status (HTTP), function (FN), db_vendor (DB).
+Buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10] seconds.
+
+Use as an AsyncCollector sink; optionally compose with other sinks:
+  registry = CollectorRegistry()
+  prom = PrometheusExporter(registry, service="myapp")
+  def sink(batch):
+      console_exporter(batch)
+      prom(batch)
+  collector = AsyncCollector(sink, ...)
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterable
+from typing import Any
+
+try:
+    from prometheus_client import CollectorRegistry, Counter, Histogram
+except ImportError:  # pragma: no cover
+    CollectorRegistry = None  # type: ignore[misc, assignment]
+    Counter = None  # type: ignore[misc, assignment]
+    Histogram = None  # type: ignore[misc, assignment]
+
+__all__ = [
+    "DEFAULT_BUCKETS",
+    "PrometheusExporter",
+    "make_asgi_app",
+    "make_metrics_blueprint",
+]
+
+# Histogram buckets in seconds (issue #17)
+DEFAULT_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
+
+
+def _ns_to_seconds(dur_ns: int) -> float:
+    """Convert nanosecond duration to seconds for Prometheus."""
+    return max(0.0, dur_ns / 1e9)
+
+
+def _str(s: Any) -> str:
+    """Coerce value to string for label; empty or missing -> placeholder."""
+    if s is None:
+        return ""
+    return str(s).strip() or "-"
+
+
+def _ensure_prometheus() -> None:
+    if CollectorRegistry is None or Counter is None or Histogram is None:
+        raise ImportError(
+            "prometheus_client is required for Prometheus exporter. "
+            "Install with: pip install profilis[prometheus]"
+        )
+
+
+class PrometheusExporter:
+    """Sink that updates Prometheus counters and histograms from REQ/HTTP/FN/DB events."""
+
+    def __init__(
+        self,
+        registry: Any = None,
+        *,
+        service: str = "",
+        instance: str = "",
+        worker: str = "",
+        buckets: tuple[float, ...] = DEFAULT_BUCKETS,
+    ) -> None:
+        _ensure_prometheus()
+        self._registry = registry if registry is not None else CollectorRegistry()
+        self._service = _str(service)
+        self._instance = _str(instance)
+        self._worker = _str(worker)
+        self._buckets = buckets
+
+        # HTTP
+        self._http_requests_total = Counter(
+            "profilis_http_requests_total",
+            "Total HTTP requests",
+            ("service", "instance", "worker", "route", "status"),
+            registry=self._registry,
+        )
+        self._http_request_duration_seconds = Histogram(
+            "profilis_http_request_duration_seconds",
+            "HTTP request duration in seconds",
+            ("service", "instance", "worker", "route", "status"),
+            buckets=list(self._buckets),
+            registry=self._registry,
+        )
+
+        # Functions
+        self._function_calls_total = Counter(
+            "profilis_function_calls_total",
+            "Total function calls",
+            ("service", "instance", "worker", "function"),
+            registry=self._registry,
+        )
+        self._function_duration_seconds = Histogram(
+            "profilis_function_duration_seconds",
+            "Function call duration in seconds",
+            ("service", "instance", "worker", "function"),
+            buckets=list(self._buckets),
+            registry=self._registry,
+        )
+
+        # DB
+        self._db_queries_total = Counter(
+            "profilis_db_queries_total",
+            "Total DB queries",
+            ("service", "instance", "worker", "db_vendor"),
+            registry=self._registry,
+        )
+        self._db_query_duration_seconds = Histogram(
+            "profilis_db_query_duration_seconds",
+            "DB query duration in seconds",
+            ("service", "instance", "worker", "db_vendor"),
+            buckets=list(self._buckets),
+            registry=self._registry,
+        )
+
+    @property
+    def registry(self) -> Any:
+        return self._registry
+
+    def _labels_http(self, route: str, status: int) -> tuple[str, str, str, str, str]:
+        return (
+            self._service,
+            self._instance,
+            self._worker,
+            _str(route) or "-",
+            _str(status),
+        )
+
+    def _labels_fn(self, function: str) -> tuple[str, str, str, str]:
+        return (self._service, self._instance, self._worker, _str(function) or "-")
+
+    def _labels_db(self, db_vendor: str) -> tuple[str, str, str, str]:
+        return (self._service, self._instance, self._worker, _str(db_vendor) or "unknown")
+
+    def _process_event(self, ev: dict[str, Any]) -> None:
+        kind = ev.get("kind")
+        if kind in ("REQ", "HTTP"):
+            route = ev.get("route") or ev.get("path") or "-"
+            status = int(ev.get("status", 0))
+            dur_ns = int(ev.get("dur_ns", 0))
+            lbl_http = self._labels_http(route, status)
+            self._http_requests_total.labels(*lbl_http).inc()
+            self._http_request_duration_seconds.labels(*lbl_http).observe(_ns_to_seconds(dur_ns))
+        elif kind == "FN":
+            fn = ev.get("fn", "-")
+            dur_ns = int(ev.get("dur_ns", 0))
+            lbl_fn = self._labels_fn(fn)
+            self._function_calls_total.labels(*lbl_fn).inc()
+            self._function_duration_seconds.labels(*lbl_fn).observe(_ns_to_seconds(dur_ns))
+        elif kind == "DB":
+            db_vendor = ev.get("db_vendor") or "unknown"
+            dur_ns = int(ev.get("dur_ns", 0))
+            lbl_db = self._labels_db(db_vendor)
+            self._db_queries_total.labels(*lbl_db).inc()
+            self._db_query_duration_seconds.labels(*lbl_db).observe(_ns_to_seconds(dur_ns))
+
+    def __call__(self, batch: Iterable[dict[str, Any] | Any]) -> None:
+        for ev in batch:
+            if not isinstance(ev, dict):
+                continue
+            with contextlib.suppress(Exception):
+                self._process_event(ev)
+
+
+def make_asgi_app(registry: Any = None) -> Any:
+    """Return an ASGI app that serves /metrics (Prometheus text format).
+
+    Use with Starlette: app.mount("/metrics", make_asgi_app(registry))
+    Or with FastAPI: app.mount("/metrics", make_asgi_app(registry))
+    """
+    _ensure_prometheus()
+    try:
+        from prometheus_client import make_asgi_app as _make_asgi_app  # noqa: PLC0415
+    except ImportError:  # pragma: no cover
+        raise ImportError(
+            "prometheus_client is required. Install with: pip install profilis[prometheus]"
+        ) from None
+    return _make_asgi_app(registry)
+
+
+def make_metrics_blueprint(registry: Any = None, url_prefix: str = "") -> Any:
+    """Return a Flask blueprint that serves GET /metrics (Prometheus text format).
+
+    Usage:
+      from profilis.exporters.prometheus import make_metrics_blueprint
+      app.register_blueprint(make_metrics_blueprint(registry))  # route at /metrics
+    """
+    _ensure_prometheus()
+    from flask import Blueprint, Response  # noqa: PLC0415
+
+    try:
+        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # noqa: PLC0415
+    except ImportError:  # pragma: no cover
+        raise ImportError(
+            "prometheus_client is required. Install with: pip install profilis[prometheus]"
+        ) from None
+
+    bp = Blueprint("profilis_metrics", __name__, url_prefix=url_prefix)
+
+    @bp.route("/metrics", methods=["GET"])
+    def metrics() -> Response:
+        reg = registry
+        if reg is None:
+            try:
+                from prometheus_client import REGISTRY  # noqa: PLC0415
+
+                reg = REGISTRY
+            except ImportError:
+                raise RuntimeError("No registry provided and REGISTRY not available") from None
+        body = generate_latest(reg)
+        return Response(body, mimetype=CONTENT_TYPE_LATEST)
+
+    return bp

--- a/src/profilis/mongo/instrumentation.py
+++ b/src/profilis/mongo/instrumentation.py
@@ -147,9 +147,12 @@ class ProfilisCommandListener(CommandListener):
             }
             # Emit a short metric (like other adapters) and enqueue the meta
             with contextlib.suppress(Exception):
-                # Keep compatibility with previous Emitter.emit_db(stmt, dur_ns, rows)
-                # rows unknown for Mongo; supply -1
-                self._emitter.emit_db(target, dur_ns=dur, rows=-1)
+                self._emitter.emit_db(
+                    target,
+                    dur_ns=dur,
+                    rows=-1,
+                    db_vendor=self._cfg.vendor_label,
+                )
             with contextlib.suppress(Exception):
                 self._emitter._collector.enqueue(meta)
         except Exception:
@@ -187,7 +190,12 @@ class ProfilisCommandListener(CommandListener):
                 "ts_ns": now_ns(),
             }
             with contextlib.suppress(Exception):
-                self._emitter.emit_db(target, dur_ns=dur, rows=-1)
+                self._emitter.emit_db(
+                    target,
+                    dur_ns=dur,
+                    rows=-1,
+                    db_vendor=self._cfg.vendor_label,
+                )
             with contextlib.suppress(Exception):
                 self._emitter._collector.enqueue(meta)
         except Exception:

--- a/src/profilis/neo4j/instrumentation.py
+++ b/src/profilis/neo4j/instrumentation.py
@@ -169,7 +169,12 @@ def _wrap_sync_callable(
                 "ts_ns": now_ns(),
             }
             with contextlib.suppress(Exception):
-                emitter.emit_db(stmt_preview, dur_ns=dur, rows=-1)
+                emitter.emit_db(
+                    stmt_preview,
+                    dur_ns=dur,
+                    rows=-1,
+                    db_vendor=cfg.vendor_label,
+                )
             with contextlib.suppress(Exception):
                 emitter._collector.enqueue(meta)
 
@@ -239,7 +244,12 @@ def _wrap_async_callable(
                 "ts_ns": now_ns(),
             }
             with contextlib.suppress(Exception):
-                emitter.emit_db(stmt_preview, dur_ns=dur, rows=-1)
+                emitter.emit_db(
+                    stmt_preview,
+                    dur_ns=dur,
+                    rows=-1,
+                    db_vendor=cfg.vendor_label,
+                )
             with contextlib.suppress(Exception):
                 emitter._collector.enqueue(meta)
 

--- a/src/profilis/pyodbc/instrumentation.py
+++ b/src/profilis/pyodbc/instrumentation.py
@@ -133,10 +133,17 @@ def _get_row_count(cursor: Any) -> int:
         return -1
 
 
-def _emit_db_metrics(emitter: Emitter, stmt: str, dur: int, rows: int) -> None:
+def _emit_db_metrics(
+    emitter: Emitter,
+    stmt: str,
+    dur: int,
+    rows: int,
+    *,
+    db_vendor: str | None = None,
+) -> None:
     """Emit DB metrics, suppressing any exceptions."""
     with contextlib.suppress(Exception):
-        emitter.emit_db(stmt, dur_ns=dur, rows=rows)
+        emitter.emit_db(stmt, dur_ns=dur, rows=rows, db_vendor=db_vendor)
 
 
 def _emit_db_meta(emitter: Emitter, config: PyODBCConfig, exec_info: DBExecutionInfo) -> None:
@@ -177,7 +184,7 @@ def _create_wrapped_execute(
             dur = now_ns() - start
             stmt = _format_sql_statement(sql, config)
             rows = _get_row_count(cursor)
-            _emit_db_metrics(emitter, stmt, dur, rows)
+            _emit_db_metrics(emitter, stmt, dur, rows, db_vendor=config.vendor_label)
             exec_info = DBExecutionInfo(stmt=stmt, params=params, dur=dur, rows=rows, exc=exc)
             _emit_db_meta(emitter, config, exec_info)
 
@@ -204,7 +211,7 @@ def _create_wrapped_executemany(
             dur = now_ns() - start
             stmt = _format_sql_statement(sql, config)
             rows = _get_row_count(cursor)
-            _emit_db_metrics(emitter, stmt, dur, rows)
+            _emit_db_metrics(emitter, stmt, dur, rows, db_vendor=config.vendor_label)
             exec_info = DBExecutionInfo(stmt=stmt, params=params_seq, dur=dur, rows=rows, exc=exc)
             _emit_db_meta(emitter, config, exec_info)
 

--- a/src/profilis/sqlalchemy/instrumentation.py
+++ b/src/profilis/sqlalchemy/instrumentation.py
@@ -79,7 +79,14 @@ def instrument_engine(
             dur = now_ns() - start_ns
             stmt = redact_statement(statement, max_len=max_len) if redact else str(statement)
             rows = getattr(cursor, "rowcount", -1)
-            emitter.emit_db(stmt, dur_ns=dur, rows=int(rows) if rows is not None else -1)
+            _eng = getattr(conn, "engine", None)
+            db_vendor = getattr(getattr(_eng, "dialect", None), "name", None) if _eng else None
+            emitter.emit_db(
+                stmt,
+                dur_ns=dur,
+                rows=int(rows) if rows is not None else -1,
+                db_vendor=db_vendor,
+            )
         finally:
             if hasattr(context, "_profilis_start_ns"):
                 delattr(context, "_profilis_start_ns")

--- a/tests/test_prometheus_exporter.py
+++ b/tests/test_prometheus_exporter.py
@@ -1,0 +1,146 @@
+"""Tests for Prometheus exporter: bucket math and scrape smoke."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("prometheus_client")
+
+from profilis.exporters.prometheus import (
+    DEFAULT_BUCKETS,
+    PrometheusExporter,
+    _ns_to_seconds,
+    make_asgi_app,
+    make_metrics_blueprint,
+)
+
+# --- Bucket math ---
+
+
+def test_ns_to_seconds_basic() -> None:
+    assert _ns_to_seconds(0) == 0.0
+    assert _ns_to_seconds(1_000_000_000) == 1.0
+    assert _ns_to_seconds(500_000_000) == 0.5  # noqa: PLR2004
+    assert _ns_to_seconds(50_000_000) == 0.05  # noqa: PLR2004
+
+
+def test_ns_to_seconds_negative_clamped_to_zero() -> None:
+    assert _ns_to_seconds(-1) == 0.0
+    assert _ns_to_seconds(-999999) == 0.0
+
+
+def test_default_buckets_ordering_and_values() -> None:
+    assert DEFAULT_BUCKETS == (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
+    for i in range(len(DEFAULT_BUCKETS) - 1):
+        assert DEFAULT_BUCKETS[i] < DEFAULT_BUCKETS[i + 1]
+
+
+def test_histogram_bucket_boundaries() -> None:
+    """Observe values at bucket boundaries and verify they appear in _bucket series."""
+    from prometheus_client import CollectorRegistry, generate_latest  # noqa: PLC0415
+
+    registry = CollectorRegistry()
+    exporter = PrometheusExporter(registry, service="svc", instance="inst", worker="w")
+
+    # 0.01 s = 10_000_000 ns
+    exporter([{"kind": "HTTP", "route": "/x", "status": 200, "dur_ns": 10_000_000}])
+    # 0.5 s
+    exporter([{"kind": "REQ", "route": "/y", "status": 500, "dur_ns": 500_000_000}])
+    # 5 s
+    exporter([{"kind": "FN", "fn": "foo", "dur_ns": 5_000_000_000}])
+    # DB with vendor
+    exporter(
+        [
+            {"kind": "DB", "db_vendor": "postgresql", "dur_ns": 25_000_000},
+        ]
+    )
+
+    body = generate_latest(registry).decode()
+    assert "profilis_http_requests_total" in body
+    assert "profilis_http_request_duration_seconds" in body
+    assert "profilis_function_calls_total" in body
+    assert "profilis_function_duration_seconds" in body
+    assert "profilis_db_queries_total" in body
+    assert "profilis_db_query_duration_seconds" in body
+    assert 'route="/x"' in body or 'route="/x"' in body
+    assert 'status="200"' in body or "status='200'" in body
+    assert 'db_vendor="postgresql"' in body or "db_vendor='postgresql'" in body
+    # Histogram buckets (le=)
+    assert "profilis_http_request_duration_seconds_bucket" in body
+    assert "le=" in body
+
+
+# --- Scrape smoke ---
+
+
+def test_scrape_smoke_all_metric_types() -> None:
+    from prometheus_client import CollectorRegistry, generate_latest  # noqa: PLC0415
+
+    registry = CollectorRegistry()
+    exporter = PrometheusExporter(
+        registry,
+        service="test-svc",
+        instance="host:8080",
+        worker="1",
+    )
+
+    batch = [
+        {"kind": "REQ", "route": "/api/users", "status": 200, "dur_ns": 100_000_000},
+        {"kind": "HTTP", "route": "/health", "status": 200, "dur_ns": 5_000_000},
+        {"kind": "FN", "fn": "my_module.handler", "dur_ns": 50_000_000},
+        {"kind": "DB", "query": "SELECT 1", "dur_ns": 1_000_000, "rows": 1, "db_vendor": "sqlite"},
+    ]
+    exporter(batch)
+
+    out = generate_latest(registry).decode()
+    assert "profilis_http_requests_total" in out
+    assert "profilis_http_request_duration_seconds" in out
+    assert "profilis_function_calls_total" in out
+    assert "profilis_function_duration_seconds" in out
+    assert "profilis_db_queries_total" in out
+    assert "profilis_db_query_duration_seconds" in out
+    assert "test-svc" in out
+    assert "host:8080" in out
+
+
+def test_scrape_smoke_ignores_non_dict_and_unknown_kind() -> None:
+    from prometheus_client import CollectorRegistry, generate_latest  # noqa: PLC0415
+
+    registry = CollectorRegistry()
+    exporter = PrometheusExporter(registry)
+    batch: list[Any] = [
+        {"kind": "REQ", "route": "/a", "status": 200, "dur_ns": 1},
+        "not a dict",
+        {"kind": "UNKNOWN", "x": 1},
+        None,
+    ]
+    exporter(cast(Any, batch))
+    out = generate_latest(registry).decode()
+    assert "profilis_http_requests_total" in out
+
+
+def test_make_asgi_app_returns_callable() -> None:
+    from prometheus_client import CollectorRegistry  # noqa: PLC0415
+
+    registry = CollectorRegistry()
+    app = make_asgi_app(registry)
+    assert callable(app)
+
+
+def test_make_metrics_blueprint_route_metrics() -> None:
+    pytest.importorskip("flask")
+    from flask import Flask  # noqa: PLC0415
+    from prometheus_client import CollectorRegistry  # noqa: PLC0415
+
+    registry = CollectorRegistry()
+    PrometheusExporter(registry)([{"kind": "REQ", "route": "/m", "status": 200, "dur_ns": 0}])
+
+    bp = make_metrics_blueprint(registry)
+    assert bp.url_prefix == ""
+    app = Flask(__name__)
+    app.register_blueprint(bp)
+    resp = app.test_client().get("/metrics")
+    assert resp.status_code == 200  # noqa: PLR2004
+    assert "profilis_http_requests_total" in resp.get_data(as_text=True)


### PR DESCRIPTION
### Summary

Adds a Prometheus exporter with HTTP, function, and DB metrics (counters and histograms), configurable labels, and `/metrics` endpoints for Flask and ASGI.

### Metrics

| Category | Counter | Histogram |
|----------|---------|-----------|
| **HTTP** | `profilis_http_requests_total` | `profilis_http_request_duration_seconds` |
| **Functions** | `profilis_function_calls_total` | `profilis_function_duration_seconds` |
| **DB** | `profilis_db_queries_total` | `profilis_db_query_duration_seconds` |

- **Labels:** `service`, `instance`, `worker`, plus `route`/`status` (HTTP), `function` (FN), `db_vendor` (DB).
- **Histogram buckets (seconds):** `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10]`.

### Changes

- **`src/profilis/exporters/prometheus.py`**
  - `PrometheusExporter(registry, service=..., instance=..., worker=..., buckets=...)` used as an `AsyncCollector` sink.
  - `make_asgi_app(registry)` for ASGI (Starlette/FastAPI) — mount at `/metrics`.
  - `make_metrics_blueprint(registry)` for Flask — register blueprint for `GET /metrics`.
- **Optional dependency:** `prometheus = ["prometheus_client>=0.19"]` in `pyproject.toml` (included in `all` and `dev`).
- **Emitter:** `emit_db(..., db_vendor=None)`; instrumentations (SQLAlchemy, Neo4j, Mongo, pyodbc) pass vendor where applicable.
- **Examples:** `examples/example_prometheus.py` (Flask), `examples/example_prometheus_asgi.py` (FastAPI).
- **Tests:** `tests/test_prometheus_exporter.py` — bucket math, scrape smoke, blueprint/ASGI app.

### Usage

**Flask**

```python
from prometheus_client import CollectorRegistry
from profilis.exporters.prometheus import PrometheusExporter, make_metrics_blueprint
from profilis.core.async_collector import AsyncCollector
from profilis.flask.adapter import ProfilisFlask

registry = CollectorRegistry()
prom = PrometheusExporter(registry, service="myapp")
def sink(batch):
    other_sink(batch)
    prom(batch)
collector = AsyncCollector(sink)
ProfilisFlask(app, collector=collector, exclude_routes=["/metrics"])
app.register_blueprint(make_metrics_blueprint(registry))
```

**ASGI (FastAPI/Starlette)**

```python
app.mount("/metrics", make_asgi_app(registry))
```


Closes #17 