### PR TITLE
feat: enhance AsyncCollector and exporters with health metrics and er…

### DIFF
--- a/examples/example_prometheus.py
+++ b/examples/example_prometheus.py
@@ -28,6 +28,7 @@ from profilis.exporters.console import ConsoleExporter
 from profilis.exporters.prometheus import (
     PrometheusExporter,
     make_metrics_blueprint,
+    register_collector_health_metrics,
 )
 from profilis.flask.adapter import ProfilisFlask
 
@@ -53,6 +54,7 @@ def sink(batch: list[dict[str, Any]]) -> None:
 
 
 collector = AsyncCollector(sink, queue_size=256, flush_interval=0.2, batch_max=64)
+register_collector_health_metrics(registry, collector)
 emitter = Emitter(collector)
 
 # ------------------- Flask app -------------------

--- a/src/profilis/core/async_collector.py
+++ b/src/profilis/core/async_collector.py
@@ -3,11 +3,14 @@
 - Non-blocking enqueue (drops oldest when full)
 - Background writer thread batches and flushes to a provided sink
 - atexit handler drains remaining items
+- Graceful shutdown: best-effort flush with timeout; never blocks exit beyond timeout
+- Collector crash handling: after consecutive sink failures, sink is disabled (noop)
 
 Configuration:
 - queue_size (int): max buffer size (default 2048)
 - flush_interval (float): seconds between periodic flush attempts (default 0.5s)
 - batch_max (int): maximum batch size per sink call (default 256)
+- max_consecutive_sink_failures (int): after this many failures, disable sink (default 5)
 """
 
 from __future__ import annotations
@@ -16,6 +19,7 @@ import atexit
 import contextlib
 import threading
 import time
+import warnings
 from collections import deque
 from typing import Callable, Generic, TypeVar
 
@@ -24,8 +28,13 @@ T = TypeVar("T")
 __all__ = ["AsyncCollector"]
 
 
+def _noop_sink(batch: list[object]) -> None:
+    """No-op sink used when the real sink is disabled after repeated failures."""
+    pass
+
+
 class AsyncCollector(Generic[T]):
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         sink: Callable[[list[T]], None],
         *,
@@ -33,6 +42,7 @@ class AsyncCollector(Generic[T]):
         flush_interval: float = 0.5,
         batch_max: int = 256,
         name: str = "profilis-collector",
+        max_consecutive_sink_failures: int = 5,
     ) -> None:
         if queue_size <= 0:
             raise ValueError("queue_size must be > 0")
@@ -40,12 +50,16 @@ class AsyncCollector(Generic[T]):
             raise ValueError("batch_max must be > 0")
         if flush_interval <= 0:
             raise ValueError("flush_interval must be > 0")
+        if max_consecutive_sink_failures < 1:
+            raise ValueError("max_consecutive_sink_failures must be >= 1")
 
         self._sink = sink
+        self._original_sink = sink
         self._buf: deque[T] = deque()
         self._max = int(queue_size)
         self._batch_max = int(batch_max)
         self._interval = float(flush_interval)
+        self._max_consecutive_failures = int(max_consecutive_sink_failures)
 
         self._lock = threading.Lock()
         self._wakeup = threading.Event()
@@ -57,10 +71,18 @@ class AsyncCollector(Generic[T]):
         self.processed = 0
         self.dropped_oldest = 0
         self.flush_errors = 0
+        self._consecutive_failures = 0
+        self._sink_disabled = False
 
         # Start worker and register atexit
         self._thread.start()
         atexit.register(self._atexit)
+
+    @property
+    def queue_depth(self) -> int:
+        """Current number of items in the buffer (thread-safe)."""
+        with self._lock:
+            return len(self._buf)
 
     # -------------------------- Public API --------------------------
     def enqueue(self, item: T) -> None:
@@ -84,21 +106,24 @@ class AsyncCollector(Generic[T]):
         self._wakeup.set()
 
     def close(self, *, timeout: float = 2.0) -> None:
-        """Stop the background thread and flush any remaining items."""
+        """Stop the background thread and best-effort flush with timeout; never block exit beyond timeout."""
         if not self._stop.is_set():
             self._stop.set()
             self._wakeup.set()
+            deadline = time.monotonic() + timeout
             self._thread.join(timeout=timeout)
-            # Final drain regardless of join result
-            self._drain_all()
-            # Close the sink if it has a close method
-            if hasattr(self._sink, "close"):
+            # Best-effort drain within remaining time; never block beyond deadline
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                self._drain_all(deadline=deadline)
+            # Close the original sink if it has a close method
+            _sink = self._original_sink
+            if _sink is not None and _sink is not _noop_sink and hasattr(_sink, "close"):
                 with contextlib.suppress(Exception):
-                    self._sink.close()
-            # Also try to call finalize if the sink has that method (for JSONL exporter)
-            if hasattr(self._sink, "finalize"):
+                    _sink.close()
+            if _sink is not None and _sink is not _noop_sink and hasattr(_sink, "finalize"):
                 with contextlib.suppress(Exception):
-                    self._sink.finalize()
+                    _sink.finalize()
 
     # ------------------------- Internal ----------------------------
     def _atexit(self) -> None:
@@ -109,15 +134,27 @@ class AsyncCollector(Generic[T]):
     def _run(self) -> None:
         interval = self._interval
         while not self._stop.is_set():
-            # Wait for either a wakeup or the periodic interval
             self._wakeup.wait(timeout=interval)
             self._wakeup.clear()
+            if self._sink_disabled:
+                # Still drain the queue so we don't grow unbounded; sink is noop
+                self._flush_batches()
+                continue
             try:
                 self._flush_batches()
+                self._consecutive_failures = 0
             except Exception:
-                # Never kill the thread on sink errors
                 self.flush_errors += 1
-                # Back off briefly to avoid tight error loops
+                self._consecutive_failures += 1
+                if self._consecutive_failures >= self._max_consecutive_failures:
+                    self._sink_disabled = True
+                    self._sink = _noop_sink  # type: ignore[assignment]
+                    warnings.warn(
+                        f"AsyncCollector disabled sink after {self._consecutive_failures} "
+                        "consecutive failures; events will be dropped until restart.",
+                        UserWarning,
+                        stacklevel=0,
+                    )
                 time.sleep(min(0.05, interval))
 
     def _pop_many(self, n: int) -> list[T]:
@@ -136,18 +173,20 @@ class AsyncCollector(Generic[T]):
             batch = self._pop_many(batch_max)
             if not batch:
                 return
-            self._sink(batch)
+            self._sink(batch)  # type: ignore[arg-type]
             self.processed += len(batch)
-            # Loop to continue draining until empty to keep latency low
 
-    def _drain_all(self) -> None:
-        # Drain everything regardless of batch size
+    def _drain_all(self, *, deadline: float | None = None) -> None:
+        """Drain buffer to sink; if deadline is set, stop when past deadline to avoid blocking exit."""
+        batch_max = self._batch_max * 4
         while True:
-            batch = self._pop_many(self._batch_max * 4)
+            if deadline is not None and time.monotonic() >= deadline:
+                break
+            batch = self._pop_many(batch_max)
             if not batch:
                 break
             try:
-                self._sink(batch)
+                self._sink(batch)  # type: ignore[arg-type]
                 self.processed += len(batch)
             except Exception:
                 self.flush_errors += 1

--- a/src/profilis/exporters/jsonl.py
+++ b/src/profilis/exporters/jsonl.py
@@ -10,10 +10,12 @@ Design:
 from __future__ import annotations
 
 import contextlib
+import errno
 import json
 import os
 import threading
 import time
+import warnings
 from collections.abc import Iterable
 from datetime import datetime
 from typing import Any, BinaryIO, cast
@@ -48,6 +50,7 @@ class JSONLExporter:
         self._fh: BinaryIO | None = None
         self._opened_at = 0.0
         self._bytes = 0
+        self._disk_full_noop = False
         self._open_active()
 
     # -------- sink interface (AsyncCollector calls this) --------
@@ -60,16 +63,29 @@ class JSONLExporter:
         newline = bytes([10])
 
         with self._lock:
-            self._maybe_rotate_locked()
-            fh = self._fh
-            assert fh is not None
-            for obj in batch:
-                b = enc(obj)
-                fh.write(b)
-                fh.write(newline)
-                self._bytes += len(b) + 1
-            fh.flush()
-            self._maybe_rotate_locked()  # rotate if large batch pushed us over
+            if self._disk_full_noop:
+                return
+            try:
+                self._maybe_rotate_locked()
+                fh = self._fh
+                assert fh is not None
+                for obj in batch:
+                    b = enc(obj)
+                    fh.write(b)
+                    fh.write(newline)
+                    self._bytes += len(b) + 1
+                fh.flush()
+                self._maybe_rotate_locked()
+            except OSError as e:
+                if e.errno in (errno.ENOSPC, errno.EDQUOT):
+                    self._disk_full_noop = True
+                    warnings.warn(
+                        "JSONLExporter: disk full (ENOSPC/EDQUOT); writes are now no-op until restart.",
+                        UserWarning,
+                        stacklevel=0,
+                    )
+                else:
+                    raise
 
     def close(self) -> None:
         with self._lock:

--- a/src/profilis/exporters/prometheus.py
+++ b/src/profilis/exporters/prometheus.py
@@ -4,6 +4,8 @@ Metrics:
 - HTTP: profilis_http_requests_total, profilis_http_request_duration_seconds
 - Functions: profilis_function_calls_total, profilis_function_duration_seconds
 - DB: profilis_db_queries_total, profilis_db_query_duration_seconds
+- Collector health (optional): profilis_events_dropped_total, profilis_queue_depth
+  Use register_collector_health_metrics(registry, collector) to expose them.
 
 Labels: service, instance, worker, route, status (HTTP), function (FN), db_vendor (DB).
 Buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10] seconds.
@@ -25,16 +27,20 @@ from typing import Any
 
 try:
     from prometheus_client import CollectorRegistry, Counter, Histogram
+    from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 except ImportError:  # pragma: no cover
     CollectorRegistry = None  # type: ignore[misc, assignment]
     Counter = None  # type: ignore[misc, assignment]
     Histogram = None  # type: ignore[misc, assignment]
+    CounterMetricFamily = None  # type: ignore[misc, assignment]
+    GaugeMetricFamily = None  # type: ignore[misc, assignment]
 
 __all__ = [
     "DEFAULT_BUCKETS",
     "PrometheusExporter",
     "make_asgi_app",
     "make_metrics_blueprint",
+    "register_collector_health_metrics",
 ]
 
 # Histogram buckets in seconds (issue #17)
@@ -172,6 +178,43 @@ class PrometheusExporter:
                 continue
             with contextlib.suppress(Exception):
                 self._process_event(ev)
+
+
+def register_collector_health_metrics(registry: Any, collector: Any) -> None:
+    """Register health metrics for an AsyncCollector: profilis_events_dropped_total, profilis_queue_depth.
+
+    Call after creating your AsyncCollector and pass the same registry used for PrometheusExporter:
+      collector = AsyncCollector(sink, ...)
+      register_collector_health_metrics(registry, collector)
+    """
+    _ensure_prometheus()
+    if CounterMetricFamily is None or GaugeMetricFamily is None:
+        raise ImportError(
+            "prometheus_client is required for health metrics. "
+            "Install with: pip install profilis[prometheus]"
+        )
+
+    class _CollectorHealthCollector:
+        def __init__(self, col: Any) -> None:
+            self._col = col
+
+        def collect(self) -> Any:
+            # Scrape-time values; collector must have queue_depth and dropped_oldest
+            depth = self._col.queue_depth if hasattr(self._col, "queue_depth") else 0
+            dropped = getattr(self._col, "dropped_oldest", 0)
+            yield GaugeMetricFamily(
+                "profilis_queue_depth",
+                "Current number of events in the collector buffer",
+                value=depth,
+            )
+            c = CounterMetricFamily(
+                "profilis_events_dropped_total",
+                "Total events dropped (queue full, drop-oldest)",
+            )
+            c.add_metric([], dropped)
+            yield c
+
+    registry.register(_CollectorHealthCollector(collector))
 
 
 def make_asgi_app(registry: Any = None) -> Any:

--- a/tests/test_async_collector.py
+++ b/tests/test_async_collector.py
@@ -4,6 +4,77 @@ import time
 from profilis.core.async_collector import AsyncCollector
 
 
+def test_queue_depth_property() -> None:
+    received: list[list[int]] = []
+
+    def sink(batch: list[int]) -> None:
+        received.append(batch)
+
+    col = AsyncCollector(sink, queue_size=10, flush_interval=1.0, batch_max=5)
+    assert col.queue_depth == 0
+    col.enqueue(1)
+    col.enqueue(2)
+    # Flush may not have run yet
+    assert col.queue_depth in (0, 1, 2)
+    time.sleep(0.15)
+    col.close()
+    assert col.queue_depth == 0
+
+
+def test_exporter_raise_increments_flush_errors_and_disables_sink() -> None:
+    """Fault injection: sink that always raises; collector disables sink after N failures."""
+    call_count = 0
+
+    def failing_sink(batch: list[int]) -> None:
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("simulated exporter failure")
+
+    col = AsyncCollector(
+        failing_sink,
+        queue_size=20,
+        flush_interval=0.03,
+        batch_max=5,
+        max_consecutive_sink_failures=3,
+    )
+    for i in range(30):
+        col.enqueue(i)
+    time.sleep(0.25)
+    min_failures = 3  # matches max_consecutive_sink_failures
+    assert col.flush_errors >= min_failures
+    assert col._sink_disabled
+    # After disable, further flushes use noop so no more exceptions
+    col.close()
+    assert call_count >= min_failures
+
+
+def test_graceful_shutdown_respects_deadline() -> None:
+    """close(timeout=...) returns within timeout even if sink blocks."""
+    block_until = threading.Event()
+    sink_called = 0
+
+    def blocking_sink(batch: list[int]) -> None:
+        nonlocal sink_called
+        sink_called += len(batch)
+        block_until.wait(timeout=5.0)
+
+    col = AsyncCollector(
+        blocking_sink,
+        queue_size=50,
+        flush_interval=10.0,
+        batch_max=10,
+    )
+    for i in range(25):
+        col.enqueue(i)
+    t0 = time.monotonic()
+    col.close(timeout=0.15)
+    elapsed = time.monotonic() - t0
+    max_acceptable_block_s = 0.5
+    assert elapsed < max_acceptable_block_s, "close() must not block long after timeout"
+    # Some items may have been processed before first blocking flush
+    assert sink_called >= 0
+
+
 def test_non_blocking_and_drop_oldest_under_burst() -> None:
     received = []
     lock = threading.Lock()

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import re
 import sys
@@ -5,6 +6,8 @@ import tempfile
 import time
 from io import StringIO
 from typing import Any
+
+import pytest
 
 from profilis.core.async_collector import AsyncCollector
 from profilis.exporters.console import ConsoleExporter
@@ -51,6 +54,36 @@ def test_jsonl_rotation_by_time() -> None:
     # The collector will flush every 0.05s, but rotations may only happen once during the test
     assert len(files) >= 1, f"Expected at least 1 file, got {files}"
     assert all(ROT_RE.match(f) for f in files)
+
+
+def test_jsonl_disk_full_fallback_noop_warn_once() -> None:
+    """Simulate disk full (ENOSPC); exporter switches to noop and warns once."""
+    tmp = tempfile.mkdtemp()
+    exp = JSONLExporter(dir=tmp, rotate_bytes=10_000_000, rotate_secs=3600)
+    write_calls = 0
+
+    fh = exp._fh
+    assert fh is not None
+    original_write = fh.write
+
+    fail_after_writes = 2
+
+    def failing_write(data: bytes) -> int:
+        nonlocal write_calls
+        write_calls += 1
+        if write_calls >= fail_after_writes:
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return original_write(data)
+
+    fh.write = failing_write  # type: ignore[assignment]
+
+    with pytest.warns(UserWarning, match="disk full"):
+        exp.write_batch([{"a": 1}, {"b": 2}])
+    assert exp._disk_full_noop
+    write_calls = 0
+    exp.write_batch([{"c": 3}])
+    assert write_calls == 0
+    exp.close()
 
 
 def test_console_exporter_unicode_and_pretty_capture_stdout(monkeypatch: Any) -> None:

--- a/tests/test_prometheus_exporter.py
+++ b/tests/test_prometheus_exporter.py
@@ -1,19 +1,22 @@
-"""Tests for Prometheus exporter: bucket math and scrape smoke."""
+"""Tests for Prometheus exporter: bucket math, scrape smoke, and health metrics."""
 
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 
 import pytest
 
 pytest.importorskip("prometheus_client")
 
+from profilis.core.async_collector import AsyncCollector
 from profilis.exporters.prometheus import (
     DEFAULT_BUCKETS,
     PrometheusExporter,
     _ns_to_seconds,
     make_asgi_app,
     make_metrics_blueprint,
+    register_collector_health_metrics,
 )
 
 # --- Bucket math ---
@@ -144,3 +147,35 @@ def test_make_metrics_blueprint_route_metrics() -> None:
     resp = app.test_client().get("/metrics")
     assert resp.status_code == 200  # noqa: PLR2004
     assert "profilis_http_requests_total" in resp.get_data(as_text=True)
+
+
+def test_health_metrics_dropped_and_queue_depth() -> None:
+    """Verify profilis_events_dropped_total and profilis_queue_depth appear and reflect collector state."""
+    from prometheus_client import CollectorRegistry, generate_latest  # noqa: PLC0415
+
+    registry = CollectorRegistry()
+    received: list[list[int]] = []
+
+    def sink(batch: list[int]) -> None:
+        received.append(batch)
+        time.sleep(0.02)
+
+    col = AsyncCollector(
+        sink,
+        queue_size=8,
+        flush_interval=0.5,
+        batch_max=4,
+    )
+    register_collector_health_metrics(registry, col)
+    for i in range(20):
+        col.enqueue(i)
+    time.sleep(0.1)
+    body = generate_latest(registry).decode()
+    assert "profilis_events_dropped_total" in body
+    assert "profilis_queue_depth" in body
+    assert col.dropped_oldest > 0
+    col.close()
+    body2 = generate_latest(registry).decode()
+    assert "profilis_events_dropped_total" in body2
+    assert "profilis_queue_depth" in body2
+    assert "profilis_queue_depth 0" in body2 or "profilis_queue_depth 0.0" in body2


### PR DESCRIPTION
### Summary

Adds failure handling and bounded shutdown for the async collector and exporters so request handling stays unaffected and process exit does not block.

### Changes

#### 1. **Disk-full fallback (JSONL exporter)**  
- **File:** `src/profilis/exporters/jsonl.py`
- On `OSError` with `errno.ENOSPC` or `errno.EDQUOT` during write/flush, the exporter switches to a no-op: sets `_disk_full_noop`, emits a single `UserWarning`, and subsequent `write_batch` calls no-op so the app keeps running.

#### 2. **Collector crash handling (AsyncCollector)**  
- **File:** `src/profilis/core/async_collector.py`
- New `max_consecutive_sink_failures` (default `5`). After that many consecutive sink exceptions, the collector:
  - Replaces the sink with a no-op (keeps draining the queue),
  - Emits a single `UserWarning`,
  - Keeps the original sink reference so `close()` still calls `close`/`finalize` on it.

#### 3. **Graceful shutdown with timeout**  
- **File:** `src/profilis/core/async_collector.py`
- `close(timeout=2.0)` is now deadline-based: joins the worker for at most `timeout`, then does a best-effort drain only until the same deadline. Shutdown never blocks beyond the given timeout.

#### 4. **Health metrics (Prometheus)**  
- **File:** `src/profilis/exporters/prometheus.py`
- New metrics:
  - **`profilis_events_dropped_total`** (counter): events dropped due to drop-oldest when the queue was full.
  - **`profilis_queue_depth`** (gauge): current number of events in the collector buffer.
- New **`queue_depth`** property on `AsyncCollector` (thread-safe).
- New **`register_collector_health_metrics(registry, collector)`** to register a custom collector that exposes these on scrape.

#### 5. **Tests**
- **test_async_collector.py:** `test_queue_depth_property`, `test_exporter_raise_increments_flush_errors_and_disables_sink` (fault injection), `test_graceful_shutdown_respects_deadline`.
- **test_exporters.py:** `test_jsonl_disk_full_fallback_noop_warn_once` (ENOSPC → noop + warn once).
- **test_prometheus_exporter.py:** `test_health_metrics_dropped_and_queue_depth`.

#### 6. **Docs / example**
- `examples/example_prometheus.py` calls `register_collector_health_metrics(registry, collector)` so `/metrics` includes the new health metrics.
- Prometheus module docstring updated to mention the new metrics and `register_collector_health_metrics`.

Closes #18 